### PR TITLE
Center landing page hero buttons horizontally

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -175,14 +175,18 @@ a, .btn {
    Pills (z. B. Landingpage)
 --------------------------------------------------- */
 .pills {
-  display: flex;
+  display: grid;
   gap: 14px;
   justify-content: center;
   justify-items: center;
 }
 @media (min-width: 640px) {
-  .pills { grid-template-columns: repeat(2, max-content); }
+  .pills {
+    grid-template-columns: repeat(2, max-content);
+  }
 }
-@media (min-width: 768px) {
-  .pills { grid-template-columns: repeat(4, max-content); }
+@media (min-width: 1024px) {
+  .pills {
+    grid-template-columns: repeat(4, max-content);
+  }
 }


### PR DESCRIPTION
## Summary
- update the landing page pill layout to use a centered CSS grid so the hero buttons stay horizontally aligned across breakpoints

## Testing
- ⚠️ `npm run lint` *(blocked by interactive Next.js ESLint setup prompt)*

------
https://chatgpt.com/codex/tasks/task_b_68e511357b9483319610c084988e109c