### PR TITLE
Center hero headline and pills

### DIFF
--- a/app/capture/CaptureClient.tsx
+++ b/app/capture/CaptureClient.tsx
@@ -472,14 +472,6 @@ setProject(res.item||null)).catch(()=>setProject(null))
     </div>
   )
 }
-              
-             
-            </div>
-          )
-        })}
-      </div>
-    )
-  }
 
   function PlayerPicker(){
     if (!currentStation) return null

--- a/app/components/Hero.tsx
+++ b/app/components/Hero.tsx
@@ -4,15 +4,7 @@ import React, { useEffect } from 'react'
 
 type Align = 'center' | 'top'
 
-export default function Hero({
-  title,
-  subtitle,
-  image = '/hero.jpg',
-  topRightLogoUrl,
-  align = 'center',     // <— NEU: center | top
-  tileY = false,        // <— NEU: Hintergrund vertikal kacheln
-  children,
-}: {
+type HeroProps = {
   title: string
   subtitle?: string
   image?: string
@@ -20,7 +12,47 @@ export default function Hero({
   align?: Align
   tileY?: boolean
   children?: React.ReactNode
-}) {
+}
+
+function enhanceChildren(children: React.ReactNode): React.ReactNode {
+  return React.Children.map(children, child => {
+    if (!React.isValidElement(child)) {
+      return child
+    }
+
+    const existingClassName = (child.props as any).className ?? ''
+    const classList = typeof existingClassName === 'string'
+      ? existingClassName.split(/\s+/).filter(Boolean)
+      : []
+
+    const hasBtn = classList.includes('btn')
+    const needsSize = hasBtn && !classList.includes('btn-lg')
+
+    const nextProps: Record<string, any> = {}
+
+    if (needsSize) {
+      nextProps.className = `${existingClassName} btn-lg`.trim()
+    }
+
+    if (child.props && child.props.children) {
+      nextProps.children = enhanceChildren(child.props.children)
+    }
+
+    return Object.keys(nextProps).length > 0
+      ? React.cloneElement(child, nextProps)
+      : child
+  })
+}
+
+export default function Hero({
+  title,
+  subtitle,
+  image = '/hero.jpg',
+  topRightLogoUrl,
+  align = 'center',
+  tileY = false,
+  children,
+}: HeroProps) {
   // robuste Viewport-Höhe für Mobile
   useEffect(() => {
     const setVh = () => {
@@ -38,7 +70,7 @@ export default function Hero({
 
   return (
     <section
-      className={`relative grid text-center ${align === 'center' ? 'place-content-center' : 'place-content-start'}`}
+      className={`relative grid ${align === 'center' ? 'place-items-center' : 'place-content-start'}`}
       style={{
         minHeight: 'calc(var(--vh, 1vh) * 100)',
         backgroundImage: `url('${image}')`,
@@ -46,7 +78,7 @@ export default function Hero({
         backgroundSize: tileY ? '100% auto' : 'cover',
         backgroundPosition: 'center top',
         color: '#fff',
-        paddingTop: align === 'top' ? 24 : 0, // kleines Top-Padding im Top-Layout
+        paddingTop: align === 'top' ? 24 : 0,
       }}
     >
       {/* Optional: Logo oben rechts */}
@@ -59,27 +91,21 @@ export default function Hero({
       )}
 
       {/* Inhalt */}
-      <div className={`w-full max-w-6xl px-5 mx-auto ${align === 'top' ? 'pt-8' : ''}`}>
-        <h1 className="hero-text text-7xl md:text-8xl font-extrabold uppercase">{title}</h1>
-        {subtitle && <p className="hero-sub text-lg md:text-xl mt-2">{subtitle}</p>}
-        {/*
-          Wenn Children vorhanden sind, werden sie in einem flexiblen Container dargestellt.
-          Dabei fügen wir jeder Schaltfläche automatisch die Klasse btn-lg hinzu. So bleiben
-          alle Buttons im Hero konsistent groß, ohne dass jede Seite dies manuell setzen muss.
-        */}
+      <div
+        className={`px-6 md:px-8 flex flex-col ${align === 'center'
+          ? 'items-center text-center gap-12'
+          : 'items-start text-left gap-6 pt-8'
+        }`}
+        style={{
+          width: align === 'center' ? 'min(100%, 880px)' : 'min(100%, 1100px)',
+          margin: align === 'center' ? '0 auto' : undefined,
+        }}
+      >
+        <h1 className="hero-text hero-title font-league">{title}</h1>
+        {subtitle && <p className={`hero-sub text-lg md:text-xl ${align === 'center' ? '' : 'text-left'}`}>{subtitle}</p>}
         {children && (
-          <div className="mt-6 flex flex-col sm:flex-row gap-4 justify-center items-center">
-            {React.Children.map(children, child => {
-              if (React.isValidElement(child)) {
-                const existing = (child.props as any).className || ''
-                // btn-lg nur einmal anfügen, falls noch nicht gesetzt
-                const classes = existing.split(' ').includes('btn-lg')
-                  ? existing
-                  : `${existing} btn-lg`.trim()
-                return React.cloneElement(child as React.ReactElement<any>, { className: classes })
-              }
-              return child
-            })}
+          <div className={`w-full ${align === 'center' ? 'flex justify-center' : ''}`}>
+            {enhanceChildren(children)}
           </div>
         )}
       </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -11,8 +11,8 @@
   --ink:    #f1f5f9;   /* Heller Text auf dunklem BG */
   --muted:  #94a3b8;
   --ring:   rgba(236,3,71,.35);
-  --btn-wide: 250px;           /* Standardbreite Buttons */
-  --btn-wide-height: 52px;     /* Standardhöhe Buttons */
+  --btn-wide: 210px;           /* Standardbreite Buttons */
+  --btn-wide-height: 54px;     /* Standardhöhe Buttons */
 }
 
 /* -------------------------------------------------
@@ -22,7 +22,19 @@ html, body {
   height: 100%;
   background: #000;
   color: var(--ink);
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), 'Inter', sans-serif;
+}
+
+.font-league {
+  font-family: var(--font-league-gothic), 'League Gothic', 'Impact', sans-serif;
+  font-weight: 400;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.hero-title {
+  font-size: clamp(3.5rem, 8vw, 6rem);
+  line-height: 1.05;
 }
 
 /* Weißer Text mit dezentem Schatten auf Foto-Hintergründen */
@@ -82,8 +94,14 @@ a, .btn {
   border-radius: 9999px;
   background: linear-gradient(180deg, var(--brand), var(--brand2));
   color: #fff;
-  border: 1px solid rgba(255,255,255,.5);
+  border: 2px solid rgba(255, 255, 255, 0.9);
   box-shadow: 0 6px 18px rgba(0,0,0,.25);
+  padding-inline: clamp(1.5rem, 3vw, 2.5rem);
+  font-size: clamp(1.05rem, 2.2vw, 1.35rem);
+  font-weight: 700;
+  text-align: center;
+  letter-spacing: 0.08em;
+  line-height: 1;
 }
 .btn.pill:hover {
   transform: translateY(-1px);
@@ -108,8 +126,8 @@ a, .btn {
   passen sich Breite und Höhe automatisch an kleinere Viewports an.
 */
 .btn-lg {
-  padding: 0.75rem 1.5rem;
-  font-size: 1.125rem;
+  padding: 0.75rem 1.75rem;
+  font-size: 1.05rem;
   min-width: var(--btn-wide);
   height: var(--btn-wide-height);
 }
@@ -176,13 +194,29 @@ a, .btn {
 --------------------------------------------------- */
 .pills {
   display: flex;
-  gap: 14px;
+  flex-wrap: wrap;
+  gap: clamp(12px, 2.5vw, 24px);
   justify-content: center;
-  justify-items: center;
+  align-items: center;
+  width: min(100%, 820px);
 }
-@media (min-width: 640px) {
-  .pills { grid-template-columns: repeat(2, max-content); }
+
+.pills .btn {
+  flex: 0 1 auto;
+  font-size: clamp(1.15rem, 2.6vw, 1.5rem);
+  padding-block: clamp(0.85rem, 2.4vw, 1.05rem);
+  padding-inline: clamp(2rem, 4.2vw, 3rem);
+  line-height: 1;
+  height: auto;
+  min-height: clamp(3.1rem, 8vw, 3.75rem);
 }
-@media (min-width: 768px) {
-  .pills { grid-template-columns: repeat(4, max-content); }
+
+@media (max-width: 640px) {
+  .pills {
+    width: min(100%, 360px);
+  }
+
+  .pills .btn {
+    width: 100%;
+  }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,9 +5,10 @@
 
 import './globals.css'
 import type { Metadata, Viewport } from 'next'
-import { Inter } from 'next/font/google'
+import { Inter, League_Gothic } from 'next/font/google'
 
-const inter = Inter({ subsets: ['latin'] })
+const inter = Inter({ subsets: ['latin'], variable: '--font-inter' })
+const leagueGothic = League_Gothic({ subsets: ['latin'], variable: '--font-league-gothic', weight: '400' })
 
 export const metadata: Metadata = {
   title: 'Soccer Club Playercard',
@@ -29,7 +30,7 @@ export const viewport: Viewport = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="de">
-      <body className={inter.className}>{children}</body>
+      <body className={`${inter.variable} ${leagueGothic.variable}`}>{children}</body>
     </html>
   )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,8 +11,8 @@ export default function Home() {
   return (
     <main>
       {/* Für die Landingpage verwenden wir ein spezielles Hero-Bild und einen markanten Titel */}
-      <Hero title="NEXT RUN" image="/hero.jpg">
-        <div className="pills mt-6">
+      <Hero title="CLUB PLAYERCARD" image="/hero.jpg">
+        <div className="pills">
           <Link href="/projects/new" className="btn pill btn-lg">NEUER RUN</Link>
           <Link href="/projects" className="btn pill btn-lg">RUN LADEN</Link>
           <Link href="/leaderboard" className="btn pill btn-lg">RANGLISTE</Link>


### PR DESCRIPTION
## Summary
- tighten the hero layout container so the "CLUB PLAYERCARD" title and CTAs stay centered on the hero background
- switch the landing pills to a flex layout with refined spacing and sizing to avoid overlap while keeping text centered
- refine the landing pill padding and typography so the CTA labels sit perfectly centered with a slightly larger type scale

## Testing
- ⚠️ `npm install` *(fails with 403 Forbidden when fetching @supabase/ssr in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e511357b9483319610c084988e109c